### PR TITLE
Center search form banner text on medium screens

### DIFF
--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -58,7 +58,7 @@ const SearchForm = ({ patient }: SearchFormProps): ReactElement => {
               />
             </Box>
 
-            <Box ml={10} textAlign={{ xs: 'center', lg: 'left' }}>
+            <Box ml={{ md: 0, lg: 10 }} textAlign={{ xs: 'center', lg: 'left' }}>
               <Box fontSize={{ xs: 30, lg: 38, xl: 63 }} fontWeight={300}>
                 Let's find some clinical trials
               </Box>


### PR DESCRIPTION
Changes made:
- Removed left margin on the parent element containing the banner text when viewing the search form page on a medium screen (e.g. iPad dimensions)

Before (md size):
![image](https://user-images.githubusercontent.com/33106214/134414466-2221454a-eebc-40ec-a9c9-50e94149e855.png)

After (md size):
![image](https://user-images.githubusercontent.com/33106214/134414328-f1b29831-3c36-4150-8bd2-4abeb2319f9f.png)
