### PR TITLE
Fix overflowing study tags

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -64,6 +64,16 @@ const theme = createTheme({
         },
       ],
     },
+    MuiChip: {
+      styleOverrides: {
+        root: { display: 'flex', flexDirection: 'row', height: 'unset' },
+        label: {
+          overflowWrap: 'break-word',
+          whiteSpace: 'normal',
+          textOverflow: 'clip',
+        },
+      },
+    },
   },
   palette: {
     primary: {


### PR DESCRIPTION
# Changes made:
- Added theme styling for MuiChip to wrap text, so study tags whose text exceeds the parent study accordion's width don't break it

## Before:
| Galaxy Fold | Surface Duo | iPad | iPad Pro | Responsive (1440px) |
| - | - | - | - | - |
| ![image](https://user-images.githubusercontent.com/33106214/145472875-d4f5f422-9bff-4814-838a-893f0ad73de9.png) | ![image](https://user-images.githubusercontent.com/33106214/145472973-7f19210c-315e-4631-aaf3-111243fd7e05.png) | ![image](https://user-images.githubusercontent.com/33106214/145473157-389323ff-9800-4c6c-b411-08eb4136de9a.png) | ![image](https://user-images.githubusercontent.com/33106214/145473267-413f7eb2-9bd3-4121-8acc-813c53f314d5.png) | ![image](https://user-images.githubusercontent.com/33106214/145475391-49448745-f228-4b61-b859-04b6cf810abd.png) |

## After:
| Galaxy Fold | Surface Duo | iPad | iPad Pro | Responsive (1440px) |
| - | - | - | - | - |
| ![image](https://user-images.githubusercontent.com/33106214/145475045-c2917985-6c33-4919-bd31-93b7235d3caf.png) | ![image](https://user-images.githubusercontent.com/33106214/145474993-8656adb3-0341-41ba-a67d-450f3ac3fba1.png) | ![image](https://user-images.githubusercontent.com/33106214/145474931-fb9e4eaf-bc04-405a-8560-6e0537296d0a.png) | ![image](https://user-images.githubusercontent.com/33106214/145473384-30097845-75aa-4773-99af-5dbba6ce9619.png) | ![image](https://user-images.githubusercontent.com/33106214/145475319-884ca2df-1603-4bbc-afdd-4d8f92fd9b08.png) |