### PR TITLE
Create a full loading screen for the loading of the patient as well as the results

### DIFF
--- a/src/components/Results/ResultsHeader.tsx
+++ b/src/components/Results/ResultsHeader.tsx
@@ -13,6 +13,7 @@ export type ResultsHeaderProps = {
   alreadyHasSavedStudies: boolean;
   handleClearSavedStudies: () => void;
   handleExportStudies: () => void;
+  showExport: boolean;
 };
 
 const ResultsHeader = ({
@@ -22,6 +23,7 @@ const ResultsHeader = ({
   alreadyHasSavedStudies,
   handleClearSavedStudies,
   handleExportStudies,
+  showExport,
 }: ResultsHeaderProps): ReactElement => {
   return (
     <Stack
@@ -56,9 +58,11 @@ const ResultsHeader = ({
           </Button>
         )}
 
-        <Button sx={{ mr: 2 }} onClick={handleExportStudies}>
-          {alreadyHasSavedStudies ? 'Export Saved' : 'Export All'}
-        </Button>
+        {showExport && (
+          <Button sx={{ mr: 2 }} onClick={handleExportStudies}>
+            {alreadyHasSavedStudies ? 'Export Saved' : 'Export All'}
+          </Button>
+        )}
       </Stack>
     </Stack>
   );

--- a/src/components/Results/__tests__/ResultsHeader.test.tsx
+++ b/src/components/Results/__tests__/ResultsHeader.test.tsx
@@ -8,6 +8,7 @@ afterEach(() => {
 
 describe('<ResultsHeader />', () => {
   const isOpen = true;
+  const showExport = true;
   const toggleDrawer = jest.fn();
   const toggleMobileDrawer = jest.fn();
   const handleClearSavedStudies = jest.fn();
@@ -21,6 +22,7 @@ describe('<ResultsHeader />', () => {
       alreadyHasSavedStudies={false}
       handleClearSavedStudies={handleClearSavedStudies}
       handleExportStudies={handleExportStudies}
+      showExport={showExport}
       {...props}
     />
   );
@@ -33,6 +35,7 @@ describe('<ResultsHeader />', () => {
       alreadyHasSavedStudies={true}
       handleClearSavedStudies={handleClearSavedStudies}
       handleExportStudies={handleExportStudies}
+      showExport={showExport}
       {...props}
     />
   );

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import { Patient } from '@/utils/fhirConversionUtils';
 
 type SidebarProps = {
   patient: Patient;
+  disabled: boolean;
 };
 
 const ensureArray = (value?: string | string[]): string[] => {
@@ -16,7 +17,7 @@ const ensureArray = (value?: string | string[]): string[] => {
   return Array.isArray(value) ? value : [value];
 };
 
-const Sidebar = ({ patient }: SidebarProps): ReactElement => {
+const Sidebar = ({ patient, disabled }: SidebarProps): ReactElement => {
   const { query } = useRouter();
 
   const matchingServices = query.matchingServices || [];
@@ -45,11 +46,11 @@ const Sidebar = ({ patient }: SidebarProps): ReactElement => {
     <>
       <PatientCard patient={patient} />
 
-      <SidebarAccordion icon={<SearchIcon fontSize="large" />} title="New Search">
+      <SidebarAccordion icon={<SearchIcon fontSize="large" />} title="New Search" disabled={disabled}>
         <SearchForm fullWidth defaultValues={defaultValues} />
       </SidebarAccordion>
 
-      <SidebarAccordion defaultExpanded icon={<FilterIcon fontSize="large" />} title="Filters">
+      <SidebarAccordion defaultExpanded icon={<FilterIcon fontSize="large" />} title="Filters" disabled={disabled}>
         <p>TODO: Filters</p>
       </SidebarAccordion>
     </>

--- a/src/components/Sidebar/SidebarAccordion.tsx
+++ b/src/components/Sidebar/SidebarAccordion.tsx
@@ -7,10 +7,17 @@ export type SidebarAccordionProps = {
   defaultExpanded?: boolean;
   icon: ReactNode;
   title: string;
+  disabled: boolean;
 };
 
-const SidebarAccordion = ({ children, defaultExpanded, icon, title }: SidebarAccordionProps): ReactElement => (
-  <Accordion defaultExpanded={defaultExpanded} disableGutters square>
+const SidebarAccordion = ({
+  children,
+  defaultExpanded,
+  icon,
+  title,
+  disabled,
+}: SidebarAccordionProps): ReactElement => (
+  <Accordion defaultExpanded={defaultExpanded} disableGutters square disabled={disabled}>
     <AccordionSummary
       expandIcon={<ExpandMoreIcon fontSize="large" sx={{ color: 'common.white' }} />}
       aria-controls="sidebar-accordion-content"

--- a/src/components/Sidebar/__tests__/SidebarAccordion.test.tsx
+++ b/src/components/Sidebar/__tests__/SidebarAccordion.test.tsx
@@ -6,10 +6,11 @@ import mockUser from '@/__mocks__/user';
 const title = 'Provider Information';
 const icon = <PersonIcon fontSize="large" />;
 const child = <p>{mockUser.name}</p>;
+const disabled = false;
 
 describe('<SidebarAccordion />', () => {
   const Component = (props: Partial<SidebarAccordionProps>) => (
-    <SidebarAccordion icon={icon} title={title} {...props}>
+    <SidebarAccordion icon={icon} title={title} disabled={disabled} {...props}>
       {child}
     </SidebarAccordion>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -52,7 +52,7 @@ const App = ({ Component, pageProps, router }: AppProps): ReactElement => {
             <CssBaseline />
             {loading ? (
               <Stack minHeight="100vh" maxHeight="100vh" justifyContent="center" alignItems="center">
-                <CircularProgress size="25vh" />
+                <CircularProgress size="10vh" />
                 <Typography variant="h4" marginTop={3}>
                   Loading page...
                 </Typography>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { CacheProvider } from '@emotion/react';
-import { CssBaseline, ThemeProvider } from '@mui/material';
+import { CircularProgress, CssBaseline, Stack, ThemeProvider, Typography } from '@mui/material';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Hydrate } from 'react-query/hydration';
 import { ReactQueryDevtools } from 'react-query/devtools';
@@ -16,7 +16,23 @@ import theme from '@/styles/theme';
 
 import type { AppProps } from 'next/app';
 
-const App = ({ Component, pageProps }: AppProps): ReactElement => {
+const App = ({ Component, pageProps, router }: AppProps): ReactElement => {
+  const [loading, setLoading] = useState(false);
+  const handleStart = useCallback(() => setLoading(true), []);
+  const handleStop = useCallback(() => setLoading(false), []);
+
+  useEffect(() => {
+    router.events.on('routeChangeStart', handleStart);
+    router.events.on('routeChangeComplete', handleStop);
+    router.events.on('routeChangeError', handleStop);
+
+    return () => {
+      router.events.off('routeChangeStart', handleStart);
+      router.events.off('routeChangeComplete', handleStop);
+      router.events.off('routeChangeError', handleStop);
+    };
+  }, [handleStop, handleStart, router.events]);
+
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -34,7 +50,16 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
         <CacheProvider value={emotionCache}>
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            <Component {...pageProps} />
+            {loading ? (
+              <Stack minHeight="100vh" maxHeight="100vh" justifyContent="center" alignItems="center">
+                <CircularProgress size="25vh" />
+                <Typography variant="h4" marginTop={3}>
+                  Loading page...
+                </Typography>
+              </Stack>
+            ) : (
+              <Component {...pageProps} />
+            )}
             <ReactQueryDevtools initialIsOpen={false} />
           </ThemeProvider>
         </CacheProvider>

--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -16,6 +16,7 @@ import {
   Snackbar,
   Alert,
   SnackbarCloseReason,
+  Typography,
 } from '@mui/material';
 import styled from '@emotion/styled';
 import Header from '@/components/Header';
@@ -145,7 +146,7 @@ const ResultsPage = ({ patient, user, searchParams }: ResultsPageProps): ReactEl
             variant="temporary"
             open={mobileOpen}
           >
-            <Sidebar patient={patient} />
+            <Sidebar patient={patient} disabled={isIdle || isLoading} />
           </Drawer>
 
           <Drawer
@@ -162,7 +163,7 @@ const ResultsPage = ({ patient, user, searchParams }: ResultsPageProps): ReactEl
             anchor="left"
             open={open}
           >
-            <Sidebar patient={patient} />
+            <Sidebar patient={patient} disabled={isIdle || isLoading} />
           </Drawer>
 
           <SlidingStack
@@ -179,14 +180,17 @@ const ResultsPage = ({ patient, user, searchParams }: ResultsPageProps): ReactEl
               alreadyHasSavedStudies={alreadyHasSavedStudies}
               handleClearSavedStudies={handleClearSavedStudies}
               handleExportStudies={handleExportSavedStudies}
+              showExport={!isIdle && !isLoading}
             />
             <MainContent elevation={0} sx={{ flex: '1 1 auto', overflowY: 'auto', p: 3 }} square>
               {(isIdle || isLoading) && (
-                <Stack alignItems="center" direction="column" justifyContent="center" height="100%">
+                <Stack alignItems="center" justifyContent="center" height="100%">
                   <CircularProgress size={drawerWidth / 2} />
+                  <Typography variant="h4" marginTop={3}>
+                    Loading trials...
+                  </Typography>
                 </Stack>
               )}
-
               {!isIdle && !isLoading && (
                 <Results
                   entries={entries}

--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -182,10 +182,21 @@ const ResultsPage = ({ patient, user, searchParams }: ResultsPageProps): ReactEl
               handleExportStudies={handleExportSavedStudies}
               showExport={!isIdle && !isLoading}
             />
-            <MainContent elevation={0} sx={{ flex: '1 1 auto', overflowY: 'auto', p: 3 }} square>
+            <MainContent
+              elevation={0}
+              sx={[
+                {
+                  flex: '1 1 auto',
+                  overflowY: 'auto',
+                  p: 3,
+                },
+                (isIdle || isLoading) && { display: 'flex', justifyContent: 'center', alignItems: 'center' },
+              ]}
+              square
+            >
               {(isIdle || isLoading) && (
                 <Stack alignItems="center" justifyContent="center" height="100%">
-                  <CircularProgress size={drawerWidth / 2} />
+                  <CircularProgress size={drawerWidth / 4} />
                   <Typography variant="h4" marginTop={3}>
                     Loading trials...
                   </Typography>


### PR DESCRIPTION
Changes made:
- Disabled sidebar accordions and export trials button while results are loading
- Added text to results page loading indicator
- Displayed a loading indicator when any page is changing to another

# From Search to Results page

https://user-images.githubusercontent.com/33106214/150181158-243984f3-3225-4298-bde1-caec89d08082.mov


# From new search on Results page

https://user-images.githubusercontent.com/33106214/150181174-4762e6fc-481d-4301-a863-d65b1294794f.mov


# From Results to Search page

https://user-images.githubusercontent.com/33106214/150181182-6a7a72a9-a680-431c-96b5-a1c76614b530.mov


