### PR TITLE
Add arms and interventions

### DIFF
--- a/src/__mocks__/resultDetails.json
+++ b/src/__mocks__/resultDetails.json
@@ -35,6 +35,30 @@
       },
       "title": "Anti-Estrogen Therapy, Palbociclib, and Gedatolisib for Metastatic ER+, HER2- Breast Cancer",
       "type": "Interventional",
+      "arms": [
+        {
+          "display": "Experimental: Arm I (paclitaxel, radium Ra 223 dichloride)",
+          "description": "Patients receive paclitaxel IV over 1 hour on days 1, 8, and 15 and radium Ra 223 dichloride IV over 1 minute on day 1. Treatment with radium Ra 223 dichloride repeats every 28 days for 6 cycles and treatment with paclitaxel repeats every 28 days in the absence of disease progression or unacceptable toxicity.",
+          "interventions": [
+            {
+              "type": "Drug",
+              "title": "Paclitaxel",
+              "subtitle": "Anzatax",
+              "description": "Given IV"
+            },
+            {
+              "type": "Radiation",
+              "title": "Radium Ra 223 Dichloride",
+              "description": "Given IV"
+            }
+          ]
+        },
+        {
+          "display": "Active Comparator: Arm II (paclitaxel)",
+          "description": "Patients receive paclitaxel IV over 1 hour on days 1, 8, and 15. Cycles repeat every 28 days in the absence of disease progression or unacceptable toxicity.",
+          "interventions": []
+        }
+      ],
       "closestFacilities": [
         {
           "distance": "Unknown distance"

--- a/src/components/Results/ArmInterventions.tsx
+++ b/src/components/Results/ArmInterventions.tsx
@@ -14,7 +14,7 @@ const ArmInterventions = ({ display, description, interventions }: ArmGroup): Re
     {interventions && interventions.length > 0 && (
       <Stack>
         <Box fontWeight="600" ml={2} sx={{ textTransform: 'uppercase' }}>
-          Interventions{' '}
+          Interventions
         </Box>
         <Stack>
           {interventions.map((intervention, index) => (

--- a/src/components/Results/ArmInterventions.tsx
+++ b/src/components/Results/ArmInterventions.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import { Box, Stack } from '@mui/material';
+import { ArmGroup } from '.';
+import React from 'react';
+
+const ArmInterventions = ({ display, description, interventions }: ArmGroup): ReactElement => (
+  <Stack pb={2}>
+    <Box fontWeight="700" sx={{ textTransform: 'uppercase' }}>
+      {display}
+    </Box>
+
+    {description && <Box>{description}</Box>}
+
+    {interventions && interventions.length > 0 && (
+      <Stack>
+        <Box fontWeight="600" ml={2} sx={{ textTransform: 'uppercase' }}>
+          Interventions{' '}
+        </Box>
+        <Stack>
+          {interventions.map((intervention, index) => (
+            <Stack pb={2} key={index}>
+              <Box ml={4} fontWeight="600" sx={{ textTransform: 'uppercase' }}>
+                {intervention.type ? `${intervention.type}:` : ''} {intervention.title}{' '}
+                {intervention.subtitle ? `(${intervention.subtitle})` : ''}
+              </Box>
+              {intervention.description && <Box ml={4}>{intervention.description}</Box>}
+            </Stack>
+          ))}
+        </Stack>
+      </Stack>
+    )}
+  </Stack>
+);
+
+export default ArmInterventions;

--- a/src/components/Results/Study.tsx
+++ b/src/components/Results/Study.tsx
@@ -21,6 +21,7 @@ import { getDetails } from './utils';
 import { SaveStudyHandler } from './types';
 import UnsaveIcon from './UnsaveIcon';
 import { StudyDetailProps } from '.';
+import ArmInterventions from './ArmInterventions';
 
 type StudyProps = {
   entry: StudyDetailProps;
@@ -88,6 +89,48 @@ const Study = ({ entry, handleSaveStudy, isStudySaved }: StudyProps): ReactEleme
                       </TableCell>
                     </TableRow>
                   ))}
+
+                  {/* Arms and Interventions  */}
+                  {entry.arms && entry.arms.length > 0 && (
+                    <TableRow
+                      key={details.length}
+                      sx={{
+                        display: 'flex',
+                        flexDirection: { xs: 'column', xl: 'row' },
+                        '&:last-child td, &:last-child th': { xl: { border: 0 } },
+                        '& td': {
+                          xs: { border: 0 },
+                          xl: { borderBottom: '1px solid rgba(224, 224, 224, 1)' },
+                        },
+                      }}
+                    >
+                      <TableCell
+                        variant="head"
+                        sx={{
+                          textTransform: 'uppercase',
+                          textAlign: { xs: 'left', xl: 'right' },
+                          verticalAlign: 'top',
+                          flex: { xl: 1 },
+                        }}
+                        component="th"
+                      >
+                        Arms and Interventions
+                      </TableCell>
+
+                      <TableCell sx={{ whiteSpace: 'pre-line', flex: { xl: 7 } }} component="td">
+                        <Stack>
+                          {entry.arms.map((arm, index) => (
+                            <ArmInterventions
+                              key={index}
+                              display={arm.display}
+                              description={arm.description}
+                              interventions={arm.interventions}
+                            />
+                          ))}
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  )}
                 </TableBody>
               </Table>
             </TableContainer>

--- a/src/components/Results/Study.tsx
+++ b/src/components/Results/Study.tsx
@@ -59,32 +59,12 @@ const Study = ({ entry, handleSaveStudy, isStudySaved }: StudyProps): ReactEleme
               <Table size={isExtraLargeScreen ? 'medium' : 'small'} stickyHeader={!isExtraLargeScreen}>
                 <TableBody>
                   {details.map(({ header, body }, index) => (
-                    <TableRow
-                      key={index}
-                      sx={{
-                        display: 'flex',
-                        flexDirection: { xs: 'column', xl: 'row' },
-                        '&:last-child td, &:last-child th': { xl: { border: 0 } },
-                        '& td': {
-                          xs: { border: 0 },
-                          xl: { borderBottom: '1px solid rgba(224, 224, 224, 1)' },
-                        },
-                      }}
-                    >
-                      <TableCell
-                        variant="head"
-                        sx={{
-                          textTransform: 'uppercase',
-                          textAlign: { xs: 'left', xl: 'right' },
-                          verticalAlign: 'top',
-                          flex: { xl: 1 },
-                        }}
-                        component="th"
-                      >
+                    <TableRow key={index}>
+                      <TableCell variant="head" component="th">
                         {header}
                       </TableCell>
 
-                      <TableCell sx={{ whiteSpace: 'pre-line', flex: { xl: 7 } }} component="td">
+                      <TableCell variant="body" component="td">
                         {body}
                       </TableCell>
                     </TableRow>
@@ -92,32 +72,12 @@ const Study = ({ entry, handleSaveStudy, isStudySaved }: StudyProps): ReactEleme
 
                   {/* Arms and Interventions  */}
                   {entry.arms && entry.arms.length > 0 && (
-                    <TableRow
-                      key={details.length}
-                      sx={{
-                        display: 'flex',
-                        flexDirection: { xs: 'column', xl: 'row' },
-                        '&:last-child td, &:last-child th': { xl: { border: 0 } },
-                        '& td': {
-                          xs: { border: 0 },
-                          xl: { borderBottom: '1px solid rgba(224, 224, 224, 1)' },
-                        },
-                      }}
-                    >
-                      <TableCell
-                        variant="head"
-                        sx={{
-                          textTransform: 'uppercase',
-                          textAlign: { xs: 'left', xl: 'right' },
-                          verticalAlign: 'top',
-                          flex: { xl: 1 },
-                        }}
-                        component="th"
-                      >
+                    <TableRow key={details.length}>
+                      <TableCell variant="head" component="th">
                         Arms and Interventions
                       </TableCell>
 
-                      <TableCell sx={{ whiteSpace: 'pre-line', flex: { xl: 7 } }} component="td">
+                      <TableCell variant="body" component="td">
                         <Stack>
                           {entry.arms.map((arm, index) => (
                             <ArmInterventions

--- a/src/components/Results/__tests__/ArmInterventions.test.tsx
+++ b/src/components/Results/__tests__/ArmInterventions.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import mockSearchResults from '@/__mocks__/resultDetails.json';
+import { ArmGroup } from '../types';
+import ArmInterventions from '../ArmInterventions';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<ArmsInterventions />', () => {
+  const arms = mockSearchResults.results[0].arms as ArmGroup[];
+
+  const ComponentWithInterventions = (props: Partial<ArmGroup>) => (
+    <ArmInterventions
+      display={arms[0].display}
+      description={arms[0].description}
+      interventions={arms[0].interventions}
+      {...props}
+    ></ArmInterventions>
+  );
+
+  const ComponentWithNoInterventions = (props: Partial<ArmGroup>) => (
+    <ArmInterventions
+      display={arms[1].display}
+      description={arms[1].description}
+      interventions={arms[1].interventions}
+      {...props}
+    ></ArmInterventions>
+  );
+
+  it('renders component with interventions', () => {
+    render(<ComponentWithInterventions />);
+    // Intervention header is there
+    expect(screen.queryByText('Interventions')).toBeInTheDocument();
+
+    // Arm group titles are there with types and subtitles
+    expect(screen.queryByText('Drug: Paclitaxel (Anzatax)')).toBeInTheDocument();
+    expect(screen.queryByText('Radiation: Radium Ra 223 Dichloride')).toBeInTheDocument();
+
+    const descriptions = screen.queryAllByText(/Given IV/);
+    expect(descriptions.length).toBe(2);
+  });
+
+  it('renders component without interventions', () => {
+    render(<ComponentWithNoInterventions />);
+
+    // No interventions rendered
+    expect(screen.queryByText('Interventions')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Results/__tests__/ArmInterventions.test.tsx
+++ b/src/components/Results/__tests__/ArmInterventions.test.tsx
@@ -7,7 +7,7 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('<ArmsInterventions />', () => {
+describe('<ArmInterventions />', () => {
   const arms = mockSearchResults.results[0].arms as ArmGroup[];
 
   const ComponentWithInterventions = (props: Partial<ArmGroup>) => (

--- a/src/components/Results/types.ts
+++ b/src/components/Results/types.ts
@@ -6,6 +6,19 @@ export type LikelihoodProps = { text: string; color: string };
 export type StatusProps = { text: string; color: string };
 export type StudyDetail = { header: string; body: string };
 
+export type Intervention = {
+  type?: string;
+  title?: string;
+  subtitle?: string;
+  description?: string;
+};
+
+export type ArmGroup = {
+  display?: string;
+  description?: string;
+  interventions?: Intervention[];
+};
+
 export type StudyDetailProps = {
   trialId: string;
   conditions?: string[];
@@ -21,6 +34,7 @@ export type StudyDetailProps = {
   status?: StatusProps;
   title?: string;
   type?: string;
+  arms?: ArmGroup[];
   closestFacilities?: ContactProps[];
   locations?: Location[];
 };

--- a/src/components/Results/utils.ts
+++ b/src/components/Results/utils.ts
@@ -103,10 +103,6 @@ const getType = (study: ResearchStudy): string => {
 
 const getArmsAndInterventions = (study: ResearchStudy): ArmGroup[] => {
   const arms = {};
-  // console.log("Arm", study.arm);
-  // console.log("Interventions", study.protocol);
-  // console.log("References", study.contained.filter(item => item.resourceType == 'PlanDefinition'));
-  // console.log("Study", JSON.stringify(study, null, 2));
 
   // Dont bother if there are no arms and interventions
   const noArms: boolean = study.arm == undefined || study.arm == null || study.arm.length == 0;
@@ -147,7 +143,6 @@ const getArmsAndInterventions = (study: ResearchStudy): ArmGroup[] => {
     }
   }
 
-  console.log('Arms and interventions', JSON.stringify(Object.values(arms), null, 2));
   return Object.values(arms);
 };
 

--- a/src/components/Results/utils.ts
+++ b/src/components/Results/utils.ts
@@ -110,7 +110,7 @@ const getArmsAndInterventions = (study: ResearchStudy): ArmGroup[] => {
 
   // Dont bother if there are no arms and interventions
   const noArms: boolean = study.arm == undefined || study.arm == null || study.arm.length == 0;
-  const noInterventions: boolean = study.protocol == undefined || study.protocol == null || study.arm.length == 0;
+  const noInterventions: boolean = study.protocol == undefined || study.protocol == null || study.protocol.length == 0;
   if (noArms || noInterventions) {
     return [];
   }
@@ -121,7 +121,7 @@ const getArmsAndInterventions = (study: ResearchStudy): ArmGroup[] => {
 
   // Map the references in the protocol to the local reference
   const interventions = study?.protocol?.map(item =>
-    item.reference.length < 1 ? null : (getIntervention(item.reference.substr(1)) as PlanDefinition)
+    item.reference.length == 0 ? null : (getIntervention(item.reference.substr(1)) as PlanDefinition)
   );
 
   // Set up the arm groups -- we'll use the name of the arm group as the key.
@@ -137,13 +137,13 @@ const getArmsAndInterventions = (study: ResearchStudy): ArmGroup[] => {
   for (const intervention of interventions) {
     // Text of the subjectCodeableConcept is the arm group; this is necessary for us to map!
     if (intervention?.subjectCodeableConcept?.text) {
-      const formated_intervention = {
+      const formatted_intervention = {
         ...(intervention?.type?.text && { type: intervention.type.text }),
         ...(intervention?.title && { title: intervention.title }),
         ...(intervention?.subtitle && { subtitle: intervention.subtitle }),
         ...(intervention?.description && { description: intervention.description }),
       };
-      arms[intervention.subjectCodeableConcept.text].interventions.push(formated_intervention);
+      arms[intervention.subjectCodeableConcept.text].interventions.push(formatted_intervention);
     }
   }
 

--- a/src/components/Results/utils.ts
+++ b/src/components/Results/utils.ts
@@ -1,4 +1,4 @@
-import { BundleEntrySearch, ContactDetail, Organization, ResearchStudy, Location } from 'fhir/r4';
+import { BundleEntrySearch, ContactDetail, Organization, ResearchStudy, Location, PlanDefinition } from 'fhir/r4';
 import { format } from 'date-fns';
 import { BundleEntry, ContactProps, LikelihoodProps, StatusProps, StudyDetail, StudyDetailProps } from './types';
 import { MainRowKeys } from '@/utils/exportData';
@@ -9,6 +9,7 @@ import {
   getCoordinatesForLocations,
   getLocationCoordinates,
 } from '@/utils/distanceUtils';
+import { ArmGroup } from '.';
 
 export const getContact = (contact: ContactDetail): ContactProps => {
   return {
@@ -100,6 +101,56 @@ const getType = (study: ResearchStudy): string => {
   }
 };
 
+const getArmsAndInterventions = (study: ResearchStudy): ArmGroup[] => {
+  const arms = {};
+  // console.log("Arm", study.arm);
+  // console.log("Interventions", study.protocol);
+  // console.log("References", study.contained.filter(item => item.resourceType == 'PlanDefinition'));
+  // console.log("Study", JSON.stringify(study, null, 2));
+
+  // Dont bother if there are no arms and interventions
+  const noArms: boolean = study.arm == undefined || study.arm == null || study.arm.length == 0;
+  const noInterventions: boolean = study.protocol == undefined || study.protocol == null || study.arm.length == 0;
+  if (noArms || noInterventions) {
+    return [];
+  }
+
+  // Function for looking up local reference
+  const getIntervention = (referenceId: string) =>
+    study.contained.find(({ resourceType, id }) => resourceType === 'PlanDefinition' && referenceId === id);
+
+  // Map the references in the protocol to the local reference
+  const interventions = study?.protocol?.map(item =>
+    item.reference.length < 1 ? null : (getIntervention(item.reference.substr(1)) as PlanDefinition)
+  );
+
+  // Set up the arm groups -- we'll use the name of the arm group as the key.
+  for (const arm of study.arm) {
+    arms[arm.name] = {
+      display: arm.type ? (arm?.type?.text ? arm.type.text + ': ' + arm.name : '') : '',
+      ...(arm.description && { description: arm.description }),
+      interventions: [],
+    } as ArmGroup;
+  }
+
+  // Map the interventions to their arm group.
+  for (const intervention of interventions) {
+    // Text of the subjectCodeableConcept is the arm group; this is necessary for us to map!
+    if (intervention?.subjectCodeableConcept?.text) {
+      const formated_intervention = {
+        ...(intervention?.type?.text && { type: intervention.type.text }),
+        ...(intervention?.title && { title: intervention.title }),
+        ...(intervention?.subtitle && { subtitle: intervention.subtitle }),
+        ...(intervention?.description && { description: intervention.description }),
+      };
+      arms[intervention.subjectCodeableConcept.text].interventions.push(formated_intervention);
+    }
+  }
+
+  console.log('Arms and interventions', JSON.stringify(Object.values(arms), null, 2));
+  return Object.values(arms);
+};
+
 const getClosestFacilities = (locations: Location[], zipcode: string, numOfFacilities = 5): ContactProps[] => {
   const origin = getZipcodeCoordinates(zipcode);
   return getCoordinatesForLocations(locations)
@@ -135,6 +186,7 @@ export const getStudyDetailProps = (entry: BundleEntry, zipcode: string): StudyD
     status: getStatus(resource),
     title: getTitle(resource),
     type: getType(resource),
+    arms: getArmsAndInterventions(resource),
     closestFacilities: getClosestFacilities(locations, zipcode),
     locations: locations,
   };

--- a/src/pages/api/clinical-trial-search.ts
+++ b/src/pages/api/clinical-trial-search.ts
@@ -101,8 +101,6 @@ function buildBundle(searchParams: SearchParameters): Bundle {
     addCancerHistologyMorphology(cancerRecord ? cancerRecord : patientBundle, cancerSubtype);
   }
 
-  console.log(JSON.stringify(patientBundle, null, 2));
-
   return patientBundle;
 }
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -109,7 +109,7 @@ const theme = createTheme({
           },
         },
       },
-    }
+    },
   },
   palette: {
     primary: {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -74,6 +74,42 @@ const theme = createTheme({
         },
       },
     },
+    MuiTableCell: {
+      variants: [
+        {
+          props: { variant: 'head' },
+          style: {
+            textTransform: 'uppercase',
+            [breakpoints.between('xs', 'xl')]: { textAlign: 'left' },
+            [breakpoints.up('xl')]: { textAlign: 'right', flex: 1 },
+            verticalAlign: 'top',
+          },
+        },
+        {
+          props: { variant: 'body' },
+          style: {
+            whiteSpace: 'pre-line',
+            [breakpoints.up('xl')]: { flex: 7 },
+          },
+        },
+      ],
+    },
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          display: 'flex',
+          [breakpoints.between('xs', 'xl')]: {
+            flexDirection: 'column',
+            '& td': { border: 0 },
+          },
+          [breakpoints.up('xl')]: {
+            flexDirection: 'row',
+            '& td': { borderBottom: '1px solid rgba(224, 224, 224, 1)' },
+            '&:last-child td, &:last-child th': { border: 0 },
+          },
+        },
+      },
+    }
   },
   palette: {
     primary: {


### PR DESCRIPTION
Resolves ticket PDM-536.

Processes arms and interventions from `ResearchStudy` and displays relevant information at the bottom of study details. 

How it should appear in the details for each study:
<img width="1101" alt="Screen Shot 2022-02-24 at 11 03 15 AM" src="https://user-images.githubusercontent.com/6525651/155604383-eb3cf049-ea09-4ce7-a8f6-80b7748da02c.png">
