### PR TITLE
Set max width to account for period

### DIFF
--- a/src/components/Results/StudyHeader.tsx
+++ b/src/components/Results/StudyHeader.tsx
@@ -78,7 +78,7 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
           p={2}
           spacing={{ xs: 0, xl: 4 }}
         >
-          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} flexGrow={1}>
+          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} flex={{ xl: 4 }}>
             <Typography fontWeight="normal" lineHeight={1.2} mb={0.5} variant="h6">
               {study.title}
             </Typography>
@@ -106,7 +106,7 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
             alignSelf={{ xs: 'flex-start', xl: 'center' }}
             py={1}
             spacing={{ xs: 0, xl: 0.5 }}
-            style={{ maxWidth: 160 }}
+            flex={{ xl: 1 }}
           >
             <Stack alignItems="center" direction="row" spacing={1}>
               <TargetIcon fontSize="inherit" sx={{ color: study.likelihood.color, width: '20px' }} />

--- a/src/components/Results/StudyHeader.tsx
+++ b/src/components/Results/StudyHeader.tsx
@@ -78,7 +78,7 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
           p={2}
           spacing={{ xs: 0, xl: 4 }}
         >
-          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} flex={{ xl: "8 4" }}>
+          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} flex={{ xl: '8 4' }}>
             <Typography fontWeight="normal" lineHeight={1.2} mb={0.5} variant="h6">
               {study.title}
             </Typography>

--- a/src/components/Results/StudyHeader.tsx
+++ b/src/components/Results/StudyHeader.tsx
@@ -78,7 +78,7 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
           p={2}
           spacing={{ xs: 0, xl: 4 }}
         >
-          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} flex={{ xl: 4 }}>
+          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} flex={{ xl: "8 4" }}>
             <Typography fontWeight="normal" lineHeight={1.2} mb={0.5} variant="h6">
               {study.title}
             </Typography>

--- a/src/components/Results/StudyHeader.tsx
+++ b/src/components/Results/StudyHeader.tsx
@@ -102,7 +102,7 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
             </Stack>
           </Stack>
 
-          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} py={1} spacing={{ xs: 0, xl: 0.5 }}>
+          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} py={1} spacing={{ xs: 0, xl: 0.5 }} style={{maxWidth: 160}}>
             <Stack alignItems="center" direction="row" spacing={1}>
               <TargetIcon fontSize="inherit" sx={{ color: study.likelihood.color, width: '20px' }} />
               <Typography whiteSpace="nowrap">{study.likelihood.text}</Typography>

--- a/src/components/Results/StudyHeader.tsx
+++ b/src/components/Results/StudyHeader.tsx
@@ -102,12 +102,7 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
             </Stack>
           </Stack>
 
-          <Stack
-            alignSelf={{ xs: 'flex-start', xl: 'center' }}
-            py={1}
-            spacing={{ xs: 0, xl: 0.5 }}
-            flex={{ xl: 1 }}
-          >
+          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} py={1} spacing={{ xs: 0, xl: 0.5 }} flex={{ xl: 1 }}>
             <Stack alignItems="center" direction="row" spacing={1}>
               <TargetIcon fontSize="inherit" sx={{ color: study.likelihood.color, width: '20px' }} />
               <Typography whiteSpace="nowrap">{study.likelihood.text}</Typography>

--- a/src/components/Results/StudyHeader.tsx
+++ b/src/components/Results/StudyHeader.tsx
@@ -102,7 +102,12 @@ const StudyHeader = ({ isExpanded, study, handleSaveStudy, isStudySaved }: Study
             </Stack>
           </Stack>
 
-          <Stack alignSelf={{ xs: 'flex-start', xl: 'center' }} py={1} spacing={{ xs: 0, xl: 0.5 }} style={{maxWidth: 160}}>
+          <Stack
+            alignSelf={{ xs: 'flex-start', xl: 'center' }}
+            py={1}
+            spacing={{ xs: 0, xl: 0.5 }}
+            style={{ maxWidth: 160 }}
+          >
             <Stack alignItems="center" direction="row" spacing={1}>
               <TargetIcon fontSize="inherit" sx={{ color: study.likelihood.color, width: '20px' }} />
               <Typography whiteSpace="nowrap">{study.likelihood.text}</Typography>


### PR DESCRIPTION
Accompanies this PR: https://github.com/mcode/clinical-trial-matching-service/pull/29

Now that the period is available, this change just ensures that the part of the `StudyHeader` that has the period is not variable and will not extend past a certain width. 