### PR TITLE
Add zip code radius filtering to the app

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Should the app send the patient's zip code and radius to the matching services?
+SEND_LOCATION_DATA = false
+
+# Instead of sending the patient's zip code, what zip code should the app use instead?
+DEFAULT_ZIP_CODE = 75001
+
+# BCT still has a known issue with the UTSW zip code
+# DEFAULT_ZIP_CODE = 75390

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ module.exports = {
   reactStrictMode: true,
   publicRuntimeConfig: {
     fhirClientId: process.env.FHIR_CLIENT_ID,
+    defaultZipCode: process.env.DEFAULT_ZIP_CODE,
+    sendLocationData: eval(process.env.SEND_LOCATION_DATA),
+    reactAppDebug: eval(process.env.REACT_APP_DEBUG),
   },
   serverRuntimeConfig: {
     sessionSecretKey: process.env.SESSION_SECRET_KEY,

--- a/src/pages/api/clinical-trial-search.ts
+++ b/src/pages/api/clinical-trial-search.ts
@@ -7,6 +7,11 @@ import { getStudyDetailProps } from '@/components/Results/utils';
 import { BundleEntry, StudyDetailProps } from '@/components/Results';
 import { isAdministrativeGender } from '@/utils/fhirTypeGuards';
 import * as fhirConstants from 'src/utils/fhirConstants';
+import getConfig from 'next/config';
+
+const {
+  publicRuntimeConfig: { sendLocationData, defaultZipCode, reactAppDebug },
+} = getConfig();
 
 // Matching services and their information
 const services = {
@@ -35,7 +40,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void>
       ? searchParams.matchingServices
       : [searchParams.matchingServices];
 
-  const results = await callWrappers(chosenServices, patientBundle);
+  const results = await callWrappers(chosenServices, patientBundle, searchParams['zipcode']);
   res.status(200).json(results);
 };
 
@@ -46,12 +51,17 @@ const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void>
  * @returns
  */
 function buildBundle(searchParams: SearchParameters): Bundle {
+  const zipCode = sendLocationData ? searchParams['zipcode'] : defaultZipCode;
+  const travelDistance = sendLocationData ? searchParams['travelDistance'] : undefined;
+
+  !sendLocationData && console.log(`Using default zip code ${defaultZipCode} and travel distance ${travelDistance}`);
+
   const trialParams: Resource = {
     resourceType: 'Parameters',
     id: '0',
     parameter: [
-      ...(searchParams['zipcode'] && [{ name: 'zipCode', valueString: searchParams['zipcode'] }]),
-      ...(searchParams['travelDistance'] && [{ name: 'travelRadius', valueString: searchParams['travelDistance'] }]),
+      ...(zipCode ? [{ name: 'zipCode', valueString: zipCode }] : []),
+      ...(travelDistance ? [{ name: 'travelRadius', valueString: travelDistance }] : []),
     ],
   };
 
@@ -219,7 +229,7 @@ function buildBundle(searchParams: SearchParameters): Bundle {
       codingSystemCode,
     });
   }
-  if (process.env.REACT_APP_DEBUG == 'true') {
+  if (reactAppDebug) {
     console.log(JSON.stringify(patientBundle, null, 2));
   }
 
@@ -231,9 +241,10 @@ function buildBundle(searchParams: SearchParameters): Bundle {
  *
  * @param matchingServices Selected matching services to use
  * @param query Query to be sent to all matching services
+ * @param patientZipCode Patient's zip code which may not have been sent to matching services
  * @returns Responses from called wrappers
  */
-async function callWrappers(matchingServices: string[], query: Bundle) {
+async function callWrappers(matchingServices: string[], query: Bundle, patientZipCode: string) {
   const wrapperResults = await Promise.all(
     matchingServices.map(async service => {
       const results = await callWrapper(
@@ -253,9 +264,6 @@ async function callWrappers(matchingServices: string[], query: Bundle) {
   const combined: StudyDetailProps[] = [];
   const uniqueTrialIds = new Set<string>();
 
-  // Grab the zipcode from the query
-  const zipcode = query.entry[0].resource.parameter[0].valueString as string;
-
   wrapperResults
     .filter(result => result.status == 200)
     .forEach(searchset => {
@@ -266,7 +274,7 @@ async function callWrappers(matchingServices: string[], query: Bundle) {
         const foundDuplicateTrial = uniqueTrialIds.has(otherTrialId);
         if (!foundDuplicateTrial) {
           uniqueTrialIds.add(otherTrialId);
-          combined.push(getStudyDetailProps(entry, zipcode));
+          combined.push(getStudyDetailProps(entry, patientZipCode));
         }
       });
     });

--- a/src/queries/clinicalTrialDistanceQuery.ts
+++ b/src/queries/clinicalTrialDistanceQuery.ts
@@ -1,0 +1,27 @@
+import { ParsedUrlQuery } from 'querystring';
+import { ResultsResponse } from './clinicalTrialSearchQuery';
+import { StudyDetailProps } from '@/components/Results';
+import getConfig from 'next/config';
+
+const {
+  publicRuntimeConfig: { sendLocationData },
+} = getConfig();
+
+const clinicalTrialDistanceQuery = async (
+  response: ResultsResponse,
+  searchParams: ParsedUrlQuery
+): Promise<ResultsResponse> => {
+  // Have the matching service wrappers already filtered the results by zip code & distance? If so, don't refilter below.
+  if (sendLocationData) return response;
+
+  // Otherwise, patient zip code & distance weren't sent to the wrappers, so do that filtering here
+  const travelDistance = searchParams.travelDistance as string;
+  const isStudyWithinRange = (entry: StudyDetailProps): boolean => {
+    return (entry.closestFacilities?.[0]?.distance?.quantity || 0) <= parseInt(travelDistance as string);
+  };
+  const filtered = response.results.filter(isStudyWithinRange);
+
+  return { results: filtered, errors: response.errors };
+};
+
+export default clinicalTrialDistanceQuery;


### PR DESCRIPTION
# Changes made
* Added environment variables to configure whether a patient's zip code and radius info is sent to the matching services
* Added distance-filtering query to filter all the returned trials with the patient's location information

# Bugs
Sending a filter query with the Sidebar sorting and filter options sometimes causes a `404 Not Found`, currently observed on the SMART Health IT server.

