### PR TITLE
Updated accordions to open one-at-a-time and default parameters for n…

### DIFF
--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,16 +1,18 @@
-import type { ReactElement } from 'react';
-import { useForm, Controller } from 'react-hook-form';
-import { useRouter } from 'next/router';
-import Image from 'next/image';
-import { Box, Button, Grid, Stack, useMediaQuery, useTheme } from '@mui/material';
+import SearchImage from '@/assets/images/search.png';
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '@/queries/clinicalTrialPaginationQuery';
 import { Search as SearchIcon } from '@mui/icons-material';
-
+import { Box, Button, Grid, Stack, useMediaQuery, useTheme } from '@mui/material';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import type { ReactElement } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { SearchParameters } from 'types/search-types';
 import {
   AgeTextField,
   BiomarkersAutocomplete,
   CancerStageAutocomplete,
-  CancerTypeAutocomplete,
   CancerSubtypeAutocomplete,
+  CancerTypeAutocomplete,
   ECOGScoreAutocomplete,
   KarnofskyScoreAutocomplete,
   MedicationsAutocomplete,
@@ -20,15 +22,12 @@ import {
   TravelDistanceTextField,
   ZipcodeTextField,
 } from './FormFields';
-import SearchImage from '@/assets/images/search.png';
 import MatchingServices from './MatchingServices';
 import { SearchFormValuesType } from './types';
-import { SearchParameters, FullSearchParameters } from 'types/search-types';
 
 export type SearchFormProps = {
   defaultValues: Partial<SearchFormValuesType>;
   fullWidth?: boolean;
-  fullSearchParams?: FullSearchParameters;
 };
 
 export const formDataToSearchQuery = (data: SearchFormValuesType): SearchParameters => ({
@@ -40,13 +39,21 @@ export const formDataToSearchQuery = (data: SearchFormValuesType): SearchParamet
   matchingServices: Object.keys(data.matchingServices).filter(service => data.matchingServices[service]),
 });
 
-const SearchForm = ({ defaultValues, fullWidth, fullSearchParams }: SearchFormProps): ReactElement => {
+const SearchForm = ({ defaultValues, fullWidth }: SearchFormProps): ReactElement => {
   const router = useRouter();
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const { handleSubmit, control } = useForm<SearchFormValuesType>({ defaultValues });
   const onSubmit = (data: SearchFormValuesType) =>
-    router.push({ pathname: '/results', query: { ...fullSearchParams, ...formDataToSearchQuery(data) } });
+    router.push({
+      pathname: '/results',
+      query: {
+        ...formDataToSearchQuery(data),
+        sortingOption: 'matchLikelihood',
+        page: DEFAULT_PAGE,
+        pageSize: DEFAULT_PAGE_SIZE,
+      },
+    });
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -80,7 +87,7 @@ const SearchForm = ({ defaultValues, fullWidth, fullSearchParams }: SearchFormPr
 
         <Grid columns={8} container spacing={2} px={2} py={fullWidth ? 0 : { md: 2 }} pb={{ xs: 2 }} mt={0}>
           <Grid item xs={8}>
-            <MatchingServices control={control} fullWidth={fullWidth} />
+            <MatchingServices {...{ control, fullWidth }} />
           </Grid>
 
           <Grid item xs={8} lg={fullWidth ? 8 : 4} xl={fullWidth ? 8 : 2}>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,18 +1,17 @@
-import { ReactElement } from 'react';
-import { useRouter } from 'next/router';
-import { FilterAlt as FilterIcon, Search as SearchIcon } from '@mui/icons-material';
-
-import SidebarAccordion from './SidebarAccordion';
+import FilterForm, { FilterFormValuesType } from '@/components/FilterForm';
 import PatientCard from '@/components/PatientCard';
 import SearchForm from '@/components/SearchForm';
-import { NamedSNOMEDCode, Patient, parseNamedSNOMEDCode } from '@/utils/fhirConversionUtils';
-import FilterForm, { FilterFormValuesType } from '@/components/FilterForm';
-import { formDataToFilterQuery } from '../FilterForm/FilterForm';
-import { formDataToSearchQuery } from '../SearchForm/SearchForm';
-import { SavedStudiesState } from '../Results';
-import { FullSearchParameters } from 'types/search-types';
-import { FilterOptions } from '@/queries/clinicalTrialSearchQuery';
 import { DEFAULT_PAGE } from '@/queries/clinicalTrialPaginationQuery';
+import { FilterOptions } from '@/queries/clinicalTrialSearchQuery';
+import { NamedSNOMEDCode, parseNamedSNOMEDCode, Patient } from '@/utils/fhirConversionUtils';
+import { FilterAlt as FilterIcon, Search as SearchIcon } from '@mui/icons-material';
+import { useRouter } from 'next/router';
+import { ReactElement, SyntheticEvent, useState } from 'react';
+import { FullSearchParameters } from 'types/search-types';
+import { formDataToFilterQuery } from '../FilterForm/FilterForm';
+import { SavedStudiesState } from '../Results';
+import { formDataToSearchQuery } from '../SearchForm/SearchForm';
+import SidebarAccordion from './SidebarAccordion';
 
 type SidebarProps = {
   patient: Patient;
@@ -20,6 +19,12 @@ type SidebarProps = {
   savedStudies: SavedStudiesState;
   filterOptions: FilterOptions;
 };
+
+enum SidebarExpand {
+  Neither = 0,
+  Search,
+  Filter,
+}
 
 export const ensureArray = (value?: string | string[]): string[] => {
   if (!value) return [];
@@ -38,6 +43,11 @@ const ensureNamedSNOMEDCode = (value?: string | string[]): NamedSNOMEDCode => {
 
 const Sidebar = ({ patient, disabled, savedStudies, filterOptions }: SidebarProps): ReactElement => {
   const { query } = useRouter();
+  const [expanded, setExpanded] = useState<SidebarExpand>(SidebarExpand.Filter);
+
+  const handleChange = (panel: SidebarExpand) => (_event: SyntheticEvent, isExpanded: boolean) => {
+    setExpanded(isExpanded ? panel : SidebarExpand.Neither);
+  };
 
   const matchingServices = query.matchingServices || [];
   const defaultSearchValues = {
@@ -97,11 +107,23 @@ const Sidebar = ({ patient, disabled, savedStudies, filterOptions }: SidebarProp
     <>
       <PatientCard patient={patient} />
 
-      <SidebarAccordion icon={<SearchIcon fontSize="large" />} title="New Search" disabled={disabled}>
-        <SearchForm fullWidth defaultValues={defaultSearchValues} fullSearchParams={fullSearchParams} />
+      <SidebarAccordion
+        icon={<SearchIcon fontSize="large" />}
+        title="New Search"
+        disabled={disabled}
+        expanded={expanded === SidebarExpand.Search}
+        onChange={handleChange(SidebarExpand.Search)}
+      >
+        <SearchForm fullWidth defaultValues={defaultSearchValues} />
       </SidebarAccordion>
 
-      <SidebarAccordion defaultExpanded icon={<FilterIcon fontSize="large" />} title="Filters" disabled={disabled}>
+      <SidebarAccordion
+        icon={<FilterIcon fontSize="large" />}
+        title="Filters"
+        disabled={disabled}
+        expanded={expanded === SidebarExpand.Filter}
+        onChange={handleChange(SidebarExpand.Filter)}
+      >
         <FilterForm
           fullWidth
           defaultValues={defaultFilterValues}

--- a/src/components/Sidebar/SidebarAccordion.tsx
+++ b/src/components/Sidebar/SidebarAccordion.tsx
@@ -1,23 +1,18 @@
-import type { ReactElement, ReactNode } from 'react';
-import { Accordion, AccordionDetails, AccordionSummary, Stack, Typography } from '@mui/material';
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import { Accordion, AccordionDetails, AccordionSummary, Stack, Typography } from '@mui/material';
+import type { ReactElement, ReactNode, SyntheticEvent } from 'react';
 
 export type SidebarAccordionProps = {
   children: ReactNode;
-  defaultExpanded?: boolean;
   icon: ReactNode;
   title: string;
-  disabled: boolean;
+  disabled?: boolean;
+  expanded?: boolean;
+  onChange?: (event: SyntheticEvent<Element, Event>, expanded: boolean) => void;
 };
 
-const SidebarAccordion = ({
-  children,
-  defaultExpanded,
-  icon,
-  title,
-  disabled,
-}: SidebarAccordionProps): ReactElement => (
-  <Accordion defaultExpanded={defaultExpanded} disableGutters square disabled={disabled}>
+const SidebarAccordion = ({ children, icon, title, ...props }: SidebarAccordionProps): ReactElement => (
+  <Accordion disableGutters square {...props}>
     <AccordionSummary
       expandIcon={<ExpandMoreIcon fontSize="large" sx={{ color: 'common.white' }} />}
       aria-controls="sidebar-accordion-content"

--- a/src/components/Sidebar/__tests__/SidebarAccordion.test.tsx
+++ b/src/components/Sidebar/__tests__/SidebarAccordion.test.tsx
@@ -1,16 +1,15 @@
-import { render, screen } from '@testing-library/react';
-import { Person as PersonIcon } from '@mui/icons-material';
-import SidebarAccordion, { SidebarAccordionProps } from '../SidebarAccordion';
 import mockUser from '@/__mocks__/user';
+import { Person as PersonIcon } from '@mui/icons-material';
+import { render, screen } from '@testing-library/react';
+import SidebarAccordion, { SidebarAccordionProps } from '../SidebarAccordion';
 
 const title = 'Provider Information';
 const icon = <PersonIcon fontSize="large" />;
 const child = <p>{mockUser.name}</p>;
-const disabled = false;
 
 describe('<SidebarAccordion />', () => {
   const Component = (props: Partial<SidebarAccordionProps>) => (
-    <SidebarAccordion icon={icon} title={title} disabled={disabled} {...props}>
+    <SidebarAccordion icon={icon} title={title} {...props}>
       {child}
     </SidebarAccordion>
   );

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,13 +1,7 @@
-import React, { ReactElement } from 'react';
-import { GetServerSideProps } from 'next';
-import Head from 'next/head';
-import smart from 'fhirclient';
-import type Client from 'fhirclient/lib/Client';
-import { fhirclient } from 'fhirclient/lib/types';
-
 import Header from '@/components/Header';
 import PatientCard from '@/components/PatientCard';
 import SearchForm from '@/components/SearchForm';
+import { MCODE_STRUCTURE_DEFINITION } from '@/utils/fhirConstants';
 import {
   convertFhirEcogPerformanceStatus,
   convertFhirKarnofskyPerformanceStatus,
@@ -23,9 +17,12 @@ import {
   PrimaryCancerCondition,
   User,
 } from '@/utils/fhirConversionUtils';
-import { MCODE_STRUCTURE_DEFINITION } from '@/utils/fhirConstants';
-import { FullSearchParameters } from 'types/search-types';
-import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '@/queries/clinicalTrialPaginationQuery';
+import smart from 'fhirclient';
+import type Client from 'fhirclient/lib/Client';
+import { fhirclient } from 'fhirclient/lib/types';
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import React, { ReactElement } from 'react';
 
 type SearchPageProps = {
   patient: Patient;
@@ -77,12 +74,7 @@ const SearchPage = ({
 
       <Header userName={user?.name} />
       <PatientCard patient={patient} />
-      <SearchForm
-        defaultValues={defaultValues}
-        fullSearchParams={
-          { sortingOption: 'matchLikelihood', page: DEFAULT_PAGE, pageSize: DEFAULT_PAGE_SIZE } as FullSearchParameters
-        }
-      />
+      <SearchForm defaultValues={defaultValues} />
     </>
   );
 };


### PR DESCRIPTION
# Changes made
* Organized imports
* Updated expanding/closing sidebar accordion behavior
  1. Load search page initially, filter accordion is open by default
  2. Close filter accordion. Search accordion doesn't expand.
  3. Expand search accordion, then expand filter accordion. Search accordion closes.
  4. Expand search accordion. Filter accordion closes.
  5. Close search accordion. Filter accordion doesn't expand
* Moved default parameters for initial search page's SearchForm into SearchForm component

# Before
https://user-images.githubusercontent.com/33106214/169400053-54ef727a-64a1-4b59-8c7d-d2d845b08c15.mov

https://user-images.githubusercontent.com/33106214/169399171-0b7346ba-4bf7-4022-ae95-69a356d00c1d.mov

# After
https://user-images.githubusercontent.com/33106214/169394677-a75d87b4-b493-463c-9331-67c9c29e0f48.mov

https://user-images.githubusercontent.com/33106214/169401853-e686faed-773d-4d09-97e0-64303c32aa25.mov

# Addressed bugs
* Filter parameters should not persist from filter query to new search query since filter query should depend on search query
  1. Go to Moonshot server, select a patient
  2. Select a filter checkbox that says Unknown Study Type (or any other Unknown X).
    * Click filter. Then either a) change the patient zipcode to UTSW's 75390 or b) Uncheck/check any matching service and click Search. Results page shows 0 matching trials even though the checkbox doesn't exist on the filter options. Clicking the clear all button remedies this issue. Similarly, sorting & saved trials parameters would persist on new searches even if the new search doesn't necessarily contain the same trials from the previous search.
    * Click search. The filter checkbox state does not persist- it should not, but this would be confusing to the user if both accordions are open. 
