### PR TITLE
Sort Filter Options and Expand Study Card with Facilities

### DIFF
--- a/src/components/Results/Study.tsx
+++ b/src/components/Results/Study.tsx
@@ -32,6 +32,7 @@ type StudyProps = {
 
 const Study = ({ entry, handleSaveStudy, isStudySaved, scrollableParent }: StudyProps): ReactElement => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isFacilitiesExpanded, setFacilitiesIsExpanded] = useState(false);
   const details = getDetails(entry);
   const theme = useTheme();
   const isExtraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
@@ -50,7 +51,16 @@ const Study = ({ entry, handleSaveStudy, isStudySaved, scrollableParent }: Study
         }}
       >
         <Stack direction={{ xs: 'column', lg: 'row' }}>
-          <Stack flexGrow={1} p={2} sx={{ backgroundColor: 'common.white', maxHeight: '500px', overflowY: 'scroll' }}>
+          <Stack
+            flexGrow={1}
+            p={2}
+            sx={{
+              backgroundColor: 'common.white',
+              maxHeight: isFacilitiesExpanded ? '800px' : '500px',
+              overflowY: 'scroll',
+              transition: 'max-height 0.25s ease-in-out',
+            }}
+          >
             <TableContainer>
               <Table size={isExtraLargeScreen ? 'medium' : 'small'} stickyHeader={!isExtraLargeScreen}>
                 <TableBody>
@@ -109,7 +119,15 @@ const Study = ({ entry, handleSaveStudy, isStudySaved, scrollableParent }: Study
               <StudyContact title="Contact" contact={contact} key={index} />
             ))}
             {closestFacilities.length !== 0 && (
-              <Accordion disableGutters square sx={{ marginTop: 2 }} className="borderless">
+              <Accordion
+                disableGutters
+                square
+                sx={{ marginTop: 2 }}
+                className="borderless"
+                onChange={(_event, expanded) => {
+                  setFacilitiesIsExpanded(expanded);
+                }}
+              >
                 <AccordionSummary
                   expandIcon={<ExpandMoreIcon />}
                   aria-controls={`study-${entry.trialId}-content`}

--- a/src/components/Results/StudyTags.tsx
+++ b/src/components/Results/StudyTags.tsx
@@ -65,11 +65,13 @@ const StudyTags = ({ isExpanded, tags, scrollableParent }: StudyTagsProps): Reac
               {({ TransitionProps }) => (
                 <Fade {...TransitionProps} timeout={350}>
                   <Paper
+                    variant="outlined"
                     sx={{
                       p: 2,
                       display: 'flex',
                       flexDirection: 'row',
                       flexWrap: 'wrap',
+                      maxWidth: scrollableParent.current.clientWidth * 0.85 + 'px',
                       bgcolor: isExpanded ? 'common.gray' : 'common.grayLighter',
                     }}
                   >

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -148,5 +148,11 @@ export const getFilterOptions = (results: StudyDetailProps[], parameters: Filter
       initialized.phase.count += 1;
     }
   }
+
+  // Filter the options by name
+  for (const filter in filterOptions) {
+    filterOptions[filter] = filterOptions[filter].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
   return filterOptions;
 };


### PR DESCRIPTION
Resolves tickets [PDM-626](https://jira.mitre.org/browse/PDM-626) and [PDM-627](https://jira.mitre.org/browse/PDM-627)

* PDM-626: When expanding the Closest Facilities accordion inside of a Study accordion, the text should expand with it
* PDM-627: The filter options should now be sorted in Alphabetical order