### PR TITLE
Add service name tracking and include in export

### DIFF
--- a/src/components/Results/utils.ts
+++ b/src/components/Results/utils.ts
@@ -200,7 +200,7 @@ const getClosestFacilities = (locations: Location[], zipcode: string, numOfFacil
     .slice(0, numOfFacilities);
 };
 
-export const getStudyDetailProps = (entry: BundleEntry, zipcode: string): StudyDetailProps => {
+export const getStudyDetailProps = (entry: BundleEntry, zipcode: string, serviceName: string): StudyDetailProps => {
   const { resource, search } = entry;
   // Grab the locations so we only have to do this once
   const locations = getLocations(resource);
@@ -208,7 +208,7 @@ export const getStudyDetailProps = (entry: BundleEntry, zipcode: string): StudyD
   return {
     conditions: getConditions(resource),
     trialId: getTrialId(resource),
-    source: getSource(),
+    source: serviceName,
     description: getDescription(resource),
     eligibility: getEligibility(resource),
     keywords: getKeywords(resource),

--- a/src/components/Results/utils.ts
+++ b/src/components/Results/utils.ts
@@ -44,8 +44,6 @@ export const getDetails = (studyProps: StudyDetailProps): StudyDetail[] => {
 
 const getTrialId = (study: ResearchStudy) => study.identifier?.[0]?.value;
 
-const getSource = () => 'Unknown'; // TODO
-
 const getDescription = (study: ResearchStudy) => study.description?.trim();
 
 const getEligibility = (study: ResearchStudy) => study.enrollment?.[0]?.display.trim();

--- a/src/utils/exportData.ts
+++ b/src/utils/exportData.ts
@@ -30,6 +30,7 @@ export const MainRowKeys = {
 const getMainRow = (studyProps: StudyDetailProps): Record<string, string> =>
   convertToSpreadsheetRow([
     { header: MainRowKeys.trialId, body: studyProps.trialId },
+    { header: MainRowKeys.source, body: studyProps.source },
     { header: MainRowKeys.likelihood, body: studyProps.likelihood?.text || '' },
     { header: MainRowKeys.title, body: studyProps.title || '' },
     { header: MainRowKeys.status, body: studyProps.status?.label || '' },


### PR DESCRIPTION
Keeps track of what matching services returns a trial. Returns that in the export. Also filters out pilot trial.