### PR TITLE
Send only the code in the query

### DIFF
--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,5 +1,6 @@
 import SearchImage from '@/assets/images/search.png';
 import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '@/queries/clinicalTrialPaginationQuery';
+import { extractCodes } from '@/utils/encodeODPE';
 import generateSearchCSVString, { SearchFormManuallyAdjustedType } from '@/utils/exportSearch';
 import { CodedValueType, isEqualCodedValueType, isEqualScore, Score as CodedScore } from '@/utils/fhirConversionUtils';
 import { Download as DownloadIcon, Search as SearchIcon } from '@mui/icons-material';
@@ -42,12 +43,12 @@ export const formDataToSearchQuery = (data: SearchFormValuesType): SearchParamet
   // Boolean check is because JSON.stringify(null) === "null" and should be omitted
   cancerType: data.cancerType ? JSON.stringify(data.cancerType) : undefined,
   cancerSubtype: data.cancerSubtype ? JSON.stringify(data.cancerSubtype) : undefined,
-  metastasis: data.metastasis ? JSON.stringify(data.metastasis) : undefined,
-  biomarkers: data.biomarkers ? JSON.stringify(data.biomarkers) : undefined,
+  metastasis: data.metastasis ? JSON.stringify(extractCodes(data.metastasis)) : undefined,
+  biomarkers: data.biomarkers ? JSON.stringify(extractCodes(data.biomarkers)) : undefined,
   stage: data.stage ? JSON.stringify(data.stage) : undefined,
-  medications: data.medications ? JSON.stringify(data.medications) : undefined,
-  surgery: data.surgery ? JSON.stringify(data.surgery) : undefined,
-  radiation: data.radiation ? JSON.stringify(data.radiation) : undefined,
+  medications: data.medications ? JSON.stringify(extractCodes(data.medications)) : undefined,
+  surgery: data.surgery ? JSON.stringify(extractCodes(data.surgery)) : undefined,
+  radiation: data.radiation ? JSON.stringify(extractCodes(data.radiation)) : undefined,
   matchingServices: Object.keys(data.matchingServices).filter(service => data.matchingServices[service]),
   karnofskyScore: data.karnofskyScore ? JSON.stringify(data.karnofskyScore) : undefined,
   ecogScore: data.ecogScore ? JSON.stringify(data.ecogScore) : undefined,

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_PAGE } from '@/queries/clinicalTrialPaginationQuery';
 import { FilterOptions } from '@/queries/clinicalTrialSearchQuery';
 import { Patient } from '@/utils/fhirConversionUtils';
 import { FilterAlt as FilterIcon, Search as SearchIcon } from '@mui/icons-material';
-import { useRouter } from 'next/router';
+import { ParsedUrlQuery } from 'querystring';
 import { ReactElement, SyntheticEvent, useState } from 'react';
 import { FullSearchParameters } from 'types/search-types';
 import { formDataToFilterQuery } from '../FilterForm/FilterForm';
@@ -18,6 +18,7 @@ type SidebarProps = {
   disabled: boolean;
   savedStudies: SavedStudiesState;
   filterOptions: FilterOptions;
+  query: ParsedUrlQuery;
 };
 
 enum SidebarExpand {
@@ -31,8 +32,7 @@ export const ensureArray = (value?: string | string[]): string[] => {
   return Array.isArray(value) ? value : [value];
 };
 
-const Sidebar = ({ patient, disabled, savedStudies, filterOptions }: SidebarProps): ReactElement => {
-  const { query } = useRouter();
+const Sidebar = ({ patient, disabled, savedStudies, filterOptions, query }: SidebarProps): ReactElement => {
   const [expanded, setExpanded] = useState<SidebarExpand>(SidebarExpand.Filter);
 
   const handleChange = (panel: SidebarExpand) => (_event: SyntheticEvent, isExpanded: boolean) => {

--- a/src/utils/encodeODPE.ts
+++ b/src/utils/encodeODPE.ts
@@ -1,0 +1,59 @@
+import biomarkers from '../assets/optimizedPatientDataElements/biomarkers.json';
+import medications from '../assets/optimizedPatientDataElements/medications.json';
+import metastases from '../assets/optimizedPatientDataElements/metastases.json';
+import radiations from '../assets/optimizedPatientDataElements/radiations.json';
+import surgeries from '../assets/optimizedPatientDataElements/surgeries.json';
+import { CodedValueType } from './fhirConversionUtils';
+
+/**
+ *
+ * @param values the values to check
+ * @returns the extracted codes
+ */
+export const extractCodes = (values: CodedValueType[]): string[] => {
+  return values.map<string>(value => value.code);
+};
+
+export const convertToCodedValueTypes = <T extends CodedValueType>(values: string[], fullValues: T[]): T[] => {
+  // Soooo... the full values is likely to be an enormous array, and values is
+  // likely to be much smaller. Because of that, make a set of values we want
+  // to recreate.
+  const valueSet = new Set(values);
+  // Next, create a map that will contain those values
+  const valueMap = new Map<string, T>();
+  // Now, since we'd have to do an exhaustive search of the full values
+  // *anyway*, go ahead and do that.
+  for (const fullValue of fullValues) {
+    const code = fullValue.code;
+    if (valueSet.has(code)) {
+      // Store this in the map for later use
+      valueMap.set(code, fullValue);
+      // Remove the code from the set
+      valueSet.delete(code);
+      if (valueSet.size === 0) {
+        // We found everything, so we can stop!
+        break;
+      }
+    }
+  }
+  if (valueSet.size > 0) {
+    console.log('Warning: Unable to find values for the following code: ', valueSet);
+  }
+  // Now, use the map we created to reconstruct the values
+  return values.map<T>(value => valueMap.get(value));
+};
+
+export const convertCodesToBiomarkers = (values: string[]): CodedValueType[] =>
+  convertToCodedValueTypes(values, biomarkers as CodedValueType[]);
+
+export const convertCodesToMedications = (values: string[]): CodedValueType[] =>
+  convertToCodedValueTypes(values, medications as CodedValueType[]);
+
+export const convertCodesToMetastases = (values: string[]): CodedValueType[] =>
+  convertToCodedValueTypes(values, metastases as CodedValueType[]);
+
+export const convertCodesToRadiations = (values: string[]): CodedValueType[] =>
+  convertToCodedValueTypes(values, radiations as CodedValueType[]);
+
+export const convertCodesToSurgeries = (values: string[]): CodedValueType[] =>
+  convertToCodedValueTypes(values, surgeries as CodedValueType[]);

--- a/src/utils/exportData.ts
+++ b/src/utils/exportData.ts
@@ -35,6 +35,9 @@ export const MainRowKeys = {
 // Translates redcaps
 export const RedCapHeaders = [
   'record_id',
+  'redcap_event_name',
+  'redcap_repeat_instrument',
+  'redcap_repeat_instance',
   'trial_id',
   'source',
   'match_likelihood',
@@ -124,16 +127,19 @@ export const exportSpreadsheetData = (data: Record<string, string>[], fileName: 
 
 export const exportCsvStringData = (patientSearch: FullSearchParameters, data: StudyDetailProps[]): string => {
   const patientElements = convertPatientInfoToRedCapRow(patientSearch);
+  const record_id = uuidv4();
   const entries = data.map(entry => {
     const trialElements = convertResultsToRedCapRow(entry);
-    return { ...trialElements, ...patientElements };
+    return { record_id, ...trialElements };
   });
-  return csvStringify([RedCapHeaders]) + csvStringify(entries);
+  return csvStringify([RedCapHeaders]) + csvStringify([{ record_id, ...patientElements }]) + csvStringify(entries);
 };
 
 const convertResultsToRedCapRow = (data: StudyDetailProps) => {
   return {
-    record_id: uuidv4(),
+    redcap_event_name: 'match_arm_1',
+    redcap_repeat_instrument: 'trial_matches_intervention_arm_1',
+    redcap_repeat_instance: 'new',
     trial_id: data.trialId,
     source: data.source,
     match_likelihood: data.likelihood?.text || '',
@@ -149,6 +155,14 @@ const convertResultsToRedCapRow = (data: StudyDetailProps) => {
     contact: data.contacts?.[0]?.name || '',
     contact_phone: data.contacts?.[0]?.phone || '',
     contact_email: data.contacts?.[0]?.email || '',
+    age: '',
+    ps_scale: '',
+    ecog: '',
+    kps: '',
+    cancer_diagnosis: '',
+    histology___1: '',
+    biomarkers: '',
+    stage: '',
   };
 };
 
@@ -167,6 +181,24 @@ const convertPatientInfoToRedCapRow = (patientSearch: FullSearchParameters) => {
     : '';
 
   return {
+    redcap_event_name: 'match_arm_1',
+    redcap_repeat_instrument: '',
+    redcap_repeat_instance: '',
+    trial_id: '',
+    source: '',
+    match_likelihood: '',
+    title: '',
+    overall_status: '',
+    period: '',
+    trial_phase: '',
+    conditions: '',
+    study_type: '',
+    description: '',
+    eligibility: '',
+    sponsor: '',
+    contact: '',
+    contact_phone: '',
+    contact_email: '',
     age: patientSearch.age || '',
     ps_scale: karnofskyScore ? 1 : ecogScore || ecogScore === 0 ? 2 : '',
     ecog: ecogScore,


### PR DESCRIPTION
Rather than send the entire coded element, this sends only the actual code for the various elements, greatly reducing the amount of data sent via the query string, hopefully resolving issues with hitting the URL length limit.