### PR TITLE
Check additional fields for changes, fix biomarkers

### DIFF
--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -194,7 +194,7 @@ const SearchForm = ({ defaultValues, fullWidth, setUserId, disableLocation }: Se
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input type="hidden" name="userid" value={userId} {...register('userid', { value: userId })} />
+      <input type="hidden" name="userid" value={userId} {...register<'userid'>('userid', { value: userId })} />
       <Box bgcolor="grey.200">
         {!(fullWidth || isSmallScreen) && (
           <Box p={{ xs: 0, md: 2 }}>

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,6 +1,6 @@
 import SearchImage from '@/assets/images/search.png';
 import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '@/queries/clinicalTrialPaginationQuery';
-import { extractCodes } from '@/utils/encodeODPE';
+import { extractBiomarkerCodes, extractCodes } from '@/utils/encodeODPE';
 import generateSearchCSVString, { SearchFormManuallyAdjustedType } from '@/utils/exportSearch';
 import { CodedValueType, isEqualCodedValueType, isEqualScore, Score as CodedScore } from '@/utils/fhirConversionUtils';
 import { Download as DownloadIcon, Search as SearchIcon } from '@mui/icons-material';
@@ -46,7 +46,7 @@ export const formDataToSearchQuery = (data: SearchFormValuesType): SearchParamet
   cancerType: data.cancerType ? JSON.stringify(data.cancerType) : undefined,
   cancerSubtype: data.cancerSubtype ? JSON.stringify(data.cancerSubtype) : undefined,
   metastasis: data.metastasis ? JSON.stringify(extractCodes(data.metastasis)) : undefined,
-  biomarkers: data.biomarkers ? JSON.stringify(extractCodes(data.biomarkers)) : undefined,
+  biomarkers: data.biomarkers ? JSON.stringify(extractBiomarkerCodes(data.biomarkers)) : undefined,
   stage: data.stage ? JSON.stringify(data.stage) : undefined,
   medications: data.medications ? JSON.stringify(extractCodes(data.medications)) : undefined,
   surgery: data.surgery ? JSON.stringify(extractCodes(data.surgery)) : undefined,

--- a/src/components/SearchForm/types.ts
+++ b/src/components/SearchForm/types.ts
@@ -13,7 +13,7 @@ export type SearchFormValuesType = {
   stage: CodedValueType;
   ecogScore: Score;
   karnofskyScore: Score;
-  biomarkers: CodedValueType[];
+  biomarkers: Biomarker[];
   radiation: CodedValueType[];
   surgery: CodedValueType[];
   medications: CodedValueType[];

--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -122,6 +122,10 @@ const getSearchParams = getParameters<SearchParameters>([
   'stage',
   'ecogScore',
   'karnofskyScore',
+  'biomarkers',
+  'medications',
+  'radiation',
+  'surgery',
   // If we're not sending location data, we get all trials back
   ...(sendLocationData ? ['zipcode' as keyof SearchParameters, 'travelDistance' as keyof SearchParameters] : []),
 ]);

--- a/src/utils/__tests__/encodeODPE.test.ts
+++ b/src/utils/__tests__/encodeODPE.test.ts
@@ -1,0 +1,66 @@
+import { extractBiomarkerCodes, extractCodes, convertCodesToBiomarkers } from '../encodeODPE';
+
+describe('extractCodes()', () => {
+  it('handles an empty array', () => {
+    expect(extractCodes([])).toEqual([]);
+  });
+  it('extracts the codes with qualifiers', () => {
+    expect(
+      extractCodes([
+        {
+          entryType: 'metastasis',
+          cancerType: ['brain', 'breast', 'colon', 'lung', 'multipleMyeloma', 'prostate'],
+          code: '94381002',
+          display: 'Secondary malignant neoplasm of liver',
+          system: 'http://snomed.info/sct',
+          category: ['liver'],
+        },
+      ])
+    ).toEqual(['94381002']);
+  });
+});
+
+describe('extractBiomakerCodes()', () => {
+  it('handles an empty array', () => {
+    expect(extractBiomarkerCodes([])).toEqual([]);
+  });
+  it('extracts the codes with qualifiers', () => {
+    expect(
+      extractBiomarkerCodes([
+        {
+          entryType: 'biomarkers',
+          cancerType: ['colon'],
+          code: '31150-6',
+          display: 'ERBB2 gene duplication [Presence] in Tissue by FISH',
+          system: 'http://loinc.org',
+          category: ['erbb2_her2', 'HER2'],
+          qualifier: {
+            code: '260385009',
+            display: 'Negative (qualifier value)',
+            system: 'http://snomed.info/sct',
+          },
+        },
+      ])
+    ).toEqual(['260385009:31150-6']);
+  });
+});
+
+describe('convertCodesToBiomarkers()', () => {
+  it('recreates the qualifier', () => {
+    expect(convertCodesToBiomarkers(['260385009:31150-6'])).toEqual([
+      {
+        entryType: 'biomarkers',
+        cancerType: ['colon'],
+        code: '31150-6',
+        display: 'ERBB2 gene duplication [Presence] in Tissue by FISH',
+        system: 'http://loinc.org',
+        category: ['erbb2_her2', 'HER2'],
+        qualifier: {
+          code: '260385009',
+          display: 'Negative (qualifier value)',
+          system: 'http://snomed.info/sct',
+        },
+      },
+    ]);
+  });
+});

--- a/src/utils/__tests__/encodeODPE.test.ts
+++ b/src/utils/__tests__/encodeODPE.test.ts
@@ -1,4 +1,5 @@
 import { extractBiomarkerCodes, extractCodes, convertCodesToBiomarkers } from '../encodeODPE';
+import { CancerType } from '../fhirConversionUtils';
 
 describe('extractCodes()', () => {
   it('handles an empty array', () => {
@@ -9,7 +10,7 @@ describe('extractCodes()', () => {
       extractCodes([
         {
           entryType: 'metastasis',
-          cancerType: ['brain', 'breast', 'colon', 'lung', 'multipleMyeloma', 'prostate'],
+          cancerType: ['brain', 'breast', 'colon', 'lung', 'multipleMyeloma', 'prostate'] as CancerType[],
           code: '94381002',
           display: 'Secondary malignant neoplasm of liver',
           system: 'http://snomed.info/sct',
@@ -29,7 +30,7 @@ describe('extractBiomakerCodes()', () => {
       extractBiomarkerCodes([
         {
           entryType: 'biomarkers',
-          cancerType: ['colon'],
+          cancerType: ['colon'] as CancerType[],
           code: '31150-6',
           display: 'ERBB2 gene duplication [Presence] in Tissue by FISH',
           system: 'http://loinc.org',


### PR DESCRIPTION
- Biomarker qualifiers were dropped moving from search to results
- Results did not check if biomakers, surgeries, radiations, or medications changed when checking if cached values should be used