### PR TITLE
Add in patient profile to search bundle

### DIFF
--- a/src/pages/api/__tests__/clinical-trial-search.test.ts
+++ b/src/pages/api/__tests__/clinical-trial-search.test.ts
@@ -103,7 +103,7 @@ const expectedBundle: Bundle = {
       resource: {
         resourceType: 'Patient',
         meta: {
-          profile: ['http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient']
+          profile: ['http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient'],
         },
         id: 'test_id',
         gender: 'female',

--- a/src/pages/api/__tests__/clinical-trial-search.test.ts
+++ b/src/pages/api/__tests__/clinical-trial-search.test.ts
@@ -103,9 +103,7 @@ const expectedBundle: Bundle = {
       resource: {
         resourceType: 'Patient',
         meta: {
-          "profile": [
-            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
-          ]
+          profile: ['http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient']
         },
         id: 'test_id',
         gender: 'female',

--- a/src/pages/api/__tests__/clinical-trial-search.test.ts
+++ b/src/pages/api/__tests__/clinical-trial-search.test.ts
@@ -102,6 +102,11 @@ const expectedBundle: Bundle = {
     {
       resource: {
         resourceType: 'Patient',
+        meta: {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
+          ]
+        },
         id: 'test_id',
         gender: 'female',
         // Age is 28, test sets time to 2022, 2022-28 = 1994

--- a/src/pages/api/clinical-trial-search.ts
+++ b/src/pages/api/clinical-trial-search.ts
@@ -21,6 +21,7 @@ import { nanoid } from 'nanoid';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import getConfig from 'next/config';
 import { SearchParameters } from 'types/search-types';
+import { MCODE_CANCER_PATIENT } from '@/utils/fhirConstants';
 
 const {
   publicRuntimeConfig: { sendLocationData, defaultZipCode, defaultTravelDistance, reactAppDebug, resultsMax, services },
@@ -80,7 +81,7 @@ export function buildBundle(searchParams: SearchParameters, id?: string): Bundle
   }
 
   // Create our stub patient
-  const patient: Patient = { resourceType: 'Patient', id: id };
+  const patient: Patient = { resourceType: 'Patient', meta: { profile: [MCODE_CANCER_PATIENT] }, id: id };
 
   // Add whatever we can
   if (isAdministrativeGender(searchParams.gender)) {


### PR DESCRIPTION
Resolves issue where receiving `null` for age for TrialJectory due to missing patient profile in request Bundle.