### PR TITLE
Disable BCT for EOM branch

### DIFF
--- a/.env
+++ b/.env
@@ -14,10 +14,12 @@ DEFAULT_TRAVEL_DISTANCE = 1500
 # DEFAULT_ZIP_CODE = 75390
 
 # Comma separated list of matching services.
-MATCHING_SERVICES = breastCancerTrials, carebox, lungevity, trialjectory
+MATCHING_SERVICES = breastCancerTrials
+# MATCHING_SERVICES = breastCancerTrials, carebox, lungevity, trialjectory
 
 # Comma seperated list of matching services to enable by default.
-MATCHING_SERVICES_DEFAULT_ENABLED = breastCancerTrials, carebox, lungevity, trialjectory
+MATCHING_SERVICES_DEFAULT_ENABLED = breastCancerTrials
+# MATCHING_SERVICES_DEFAULT_ENABLED = breastCancerTrials, carebox, lungevity, trialjectory
 
 # Which site rubric to use [none, site1, site2]
 SITE_RUBRIC = site1


### PR DESCRIPTION
Change the configuration for enabled wrappers to limit to only the BCT wrapper within the EOM branch.