### PR TITLE
Add configuration options for FHIR queries used

### DIFF
--- a/.env
+++ b/.env
@@ -36,6 +36,13 @@ FHIR_REDIRECT_URI = "http://localhost:3200"
 # For Epic, this should be "launch user/*.* openid fhirUser".
 FHIR_SCOPE = "launch/patient openid fhirUser patient/*.read"
 
+# Extra query parameters. Should be formatted as URL parameters (it will
+# effectively be appended to the query)
+# FHIR_QUERY_CONDITION =
+FHIR_QUERY_OBSERVATION = "category=vital-signs,social-history,laboratory"
+# FHIR_QUERY_PROCEDURE =
+# FHIR_QUERY_MEDICATIONREQUEST
+
 # Either "epic" to use the Epic patient data queries or "sandbox" to use the
 # sandbox ones.
 SMART_FHIR_FLAVOR = sandbox

--- a/src/utils/fhir/__tests__/fetch.test.ts
+++ b/src/utils/fhir/__tests__/fetch.test.ts
@@ -1,4 +1,4 @@
-import { parseFHIRDate, compareDates } from '../fetch';
+import { compareDates, createQueryConfig, parseFHIRDate } from '../fetch';
 
 describe('compareDates()', () => {
   it('compares undefined after other dates', () => {
@@ -31,5 +31,17 @@ describe('parseFHIRDate()', () => {
   });
   it('parses a date with an explicit timezone', () => {
     expect(parseFHIRDate('2004-03-15T15:23:49-04:00')).toEqual(Date.UTC(2004, 2, 15, 19, 23, 49));
+  });
+});
+
+describe('createQueryConfig()', () => {
+  it('returns undefined for an unset entry', () => {
+    delete process.env['FHIR_QUERY_TESTSCRIPT'];
+    expect(createQueryConfig('TestScript')).toBeUndefined();
+  });
+
+  it('returns the configured value', () => {
+    process.env['FHIR_QUERY_TESTSCRIPT'] = 'category=test&other=thing';
+    expect(createQueryConfig('TestScript')).toEqual({ category: 'test', other: 'thing' });
   });
 });

--- a/src/utils/fhir/fetch.ts
+++ b/src/utils/fhir/fetch.ts
@@ -86,7 +86,10 @@ export const fetchResources = async <T extends FhirResource>(
  * Retrieves all known medications from the current patient.
  * @param fhirClient the client to retrieve medications from
  */
-export const fetchMedications = async (fhirClient: Client, parameters?: Record<string, string>): Promise<Medication[]> => {
+export const fetchMedications = async (
+  fhirClient: Client,
+  parameters?: Record<string, string>
+): Promise<Medication[]> => {
   const medications: Promise<Medication>[] = [];
   for (const medRequest of await fetchResources<MedicationRequest>(fhirClient, 'MedicationRequest', parameters)) {
     // See if this requires the medication be loaded separately

--- a/src/utils/sandbox/__tests__/fetchPatientData.test.ts
+++ b/src/utils/sandbox/__tests__/fetchPatientData.test.ts
@@ -86,10 +86,13 @@ describe('fetchPatientData', () => {
       medications: [],
     });
     expect(requestSpy).toHaveBeenCalledTimes(4);
-    expect(requestSpy.mock.calls[0]).toEqual(['Condition?patient=test-patient&type=condition', {pageLimit: 0}]);
-    expect(requestSpy.mock.calls[1]).toEqual(['Observation?patient=test-patient&type=observation', {pageLimit: 0}]);
-    expect(requestSpy.mock.calls[2]).toEqual(['Procedure?patient=test-patient&type=procedure', {pageLimit: 0}]);
-    expect(requestSpy.mock.calls[3]).toEqual(['MedicationRequest?patient=test-patient&type=medicationrequest', {pageLimit: 0}]);
+    expect(requestSpy.mock.calls[0]).toEqual(['Condition?patient=test-patient&type=condition', { pageLimit: 0 }]);
+    expect(requestSpy.mock.calls[1]).toEqual(['Observation?patient=test-patient&type=observation', { pageLimit: 0 }]);
+    expect(requestSpy.mock.calls[2]).toEqual(['Procedure?patient=test-patient&type=procedure', { pageLimit: 0 }]);
+    expect(requestSpy.mock.calls[3]).toEqual([
+      'MedicationRequest?patient=test-patient&type=medicationrequest',
+      { pageLimit: 0 },
+    ]);
   });
 });
 

--- a/src/utils/sandbox/__tests__/fetchPatientData.test.ts
+++ b/src/utils/sandbox/__tests__/fetchPatientData.test.ts
@@ -19,6 +19,29 @@ const testUser = testPatient;
 
 describe('fetchPatientData', () => {
   it('fetches data', async () => {
+    // "Configure" test data
+    process.env['FHIR_QUERY_CONDITION'] = 'type=condition';
+    process.env['FHIR_QUERY_OBSERVATION'] = 'type=observation';
+    process.env['FHIR_QUERY_PROCEDURE'] = 'type=procedure';
+    process.env['FHIR_QUERY_MEDICATIONREQUEST'] = 'type=medicationrequest';
+    // Spy for requests
+    const requestSpy = jest.fn(async (query: string, options?: fhirclient.FhirOptions): Promise<Bundle | Bundle[]> => {
+      // For now, always return an empty bundle (or an array of a single empty bundle)
+      if ('pageLimit' in options) {
+        return [
+          {
+            resourceType: 'Bundle',
+            type: 'searchset',
+            entry: [],
+          },
+        ];
+      }
+      return {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [],
+      };
+    });
     // This is a mock client, it's intentionally missing things the real one would have
     const fhirClient = {
       patient: {
@@ -28,23 +51,7 @@ describe('fetchPatientData', () => {
         read: () => Promise.resolve(testUser),
       },
       getPatientId: () => 'test-patient',
-      request: async (query: string, options?: fhirclient.FhirOptions): Promise<Bundle | Bundle[]> => {
-        // For now, always return an empty bundle (or an array of a single empty bundle)
-        if ('pageLimit' in options) {
-          return [
-            {
-              resourceType: 'Bundle',
-              type: 'searchset',
-              entry: [],
-            },
-          ];
-        }
-        return {
-          resourceType: 'Bundle',
-          type: 'searchset',
-          entry: [],
-        };
-      },
+      request: requestSpy,
     } as unknown as Client;
     const patientData = await fetchPatientData(fhirClient, () => {
       /* no-op */
@@ -78,6 +85,11 @@ describe('fetchPatientData', () => {
       surgery: [],
       medications: [],
     });
+    expect(requestSpy).toHaveBeenCalledTimes(4);
+    expect(requestSpy.mock.calls[0]).toEqual(['Condition?patient=test-patient&type=condition', {pageLimit: 0}]);
+    expect(requestSpy.mock.calls[1]).toEqual(['Observation?patient=test-patient&type=observation', {pageLimit: 0}]);
+    expect(requestSpy.mock.calls[2]).toEqual(['Procedure?patient=test-patient&type=procedure', {pageLimit: 0}]);
+    expect(requestSpy.mock.calls[3]).toEqual(['MedicationRequest?patient=test-patient&type=medicationrequest', {pageLimit: 0}]);
   });
 });
 

--- a/src/utils/sandbox/fetchPatientData.ts
+++ b/src/utils/sandbox/fetchPatientData.ts
@@ -33,7 +33,7 @@ import {
 import type Client from 'fhirclient/lib/Client';
 import { fhirclient } from 'fhirclient/lib/types';
 import type { PatientData, ProgressMonitor } from '../fetchPatientData';
-import { fetchMedications, fetchResources, observationHasCode, sortByDate } from '../fhir/fetch';
+import { createQueryConfig, fetchMedications, fetchResources, observationHasCode, sortByDate } from '../fhir/fetch';
 import { Condition, Medication, Observation, Procedure } from 'fhir/r4';
 
 export type FetchTaskType = [
@@ -61,10 +61,10 @@ export const fetchPatientData = async (fhirClient: Client, progress: ProgressMon
   const tasks: FetchTaskPromiseType = [
     fhirClient.patient.read(),
     fhirClient.user.read(),
-    fetchResources<Condition>(fhirClient, 'Condition'),
-    fetchResources<Observation>(fhirClient, 'Observation', { category: 'vital-signs,social-history,laboratory'}),
-    fetchResources<Procedure>(fhirClient, 'Procedure'),
-    fetchMedications(fhirClient),
+    fetchResources<Condition>(fhirClient, 'Condition', createQueryConfig('Condition')),
+    fetchResources<Observation>(fhirClient, 'Observation', createQueryConfig('Observation')),
+    fetchResources<Procedure>(fhirClient, 'Procedure', createQueryConfig('Procedure')),
+    fetchMedications(fhirClient, createQueryConfig('MedicationRequest')),
   ];
   progress('Fetching patient data...', 0, tasks.length);
 

--- a/src/utils/sandbox/fetchPatientData.ts
+++ b/src/utils/sandbox/fetchPatientData.ts
@@ -62,7 +62,7 @@ export const fetchPatientData = async (fhirClient: Client, progress: ProgressMon
     fhirClient.patient.read(),
     fhirClient.user.read(),
     fetchResources<Condition>(fhirClient, 'Condition'),
-    fetchResources<Observation>(fhirClient, 'Observation'),
+    fetchResources<Observation>(fhirClient, 'Observation', { category: 'vital-signs,social-history,laboratory'}),
     fetchResources<Procedure>(fhirClient, 'Procedure'),
     fetchMedications(fhirClient),
   ];


### PR DESCRIPTION
Allows additional query parameters to be specified in the `.env` file, allowing individual sites to customize the way data is loaded as necessary based on the EHR in use.