### PR TITLE
Updating labels to match EOM names and add EOM indicator

### DIFF
--- a/src/components/SearchForm/FormFields.tsx
+++ b/src/components/SearchForm/FormFields.tsx
@@ -90,7 +90,7 @@ export const AgeTextField = ({
   field,
 }: {
   field: ControllerRenderProps<SearchFormValuesType, 'age'>;
-}): ReactElement => <TextField data-testid="age" fullWidth label="Age" type="number" variant="filled" {...field} />;
+}): ReactElement => <TextField data-testid="age" fullWidth label="Age ⓘ" type="number" variant="filled" {...field} />;
 
 export const CancerTypeAutocomplete = ({
   field,
@@ -114,7 +114,7 @@ export const CancerTypeAutocomplete = ({
       renderInput={params => (
         <TextField
           variant="filled"
-          label="Cancer Type"
+          label="Cancer Diagnosis ⓘ"
           placeholder=""
           required
           error={field.value === null}
@@ -146,10 +146,10 @@ export const CancerSubtypeAutocomplete = ({
       renderInput={params => (
         <TextField
           variant="filled"
-          label="Cancer Subtype"
+          label="Histology"
           placeholder=""
           error={!subtypeIsValid()}
-          helperText={!subtypeIsValid() ? 'Invalid cancer subtype.' : undefined}
+          helperText={!subtypeIsValid() ? 'Invalid histology.' : undefined}
           {...params}
         />
       )}
@@ -205,7 +205,7 @@ export const DiseaseStatusAutocomplete = ({
       onChange={(_, value) => field.onChange(value)}
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
-      renderInput={params => <TextField variant="filled" label="Disease Status" placeholder="" {...params} />}
+      renderInput={params => <TextField variant="filled" label="Disease Status ⓘ" placeholder="" {...params} />}
       isOptionEqualToValue={areCodedValueTypesEqual}
     />
   );
@@ -225,7 +225,9 @@ export const PrimaryTumorStageAutocomplete = ({
       onChange={(_, value) => field.onChange(value)}
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
-      renderInput={params => <TextField variant="filled" label="Primary Tumor (T) Stage" placeholder="" {...params} />}
+      renderInput={params => (
+        <TextField variant="filled" label="Primary Tumor (T) Stage ⓘ" placeholder="" {...params} />
+      )}
       isOptionEqualToValue={areCodedValueTypesEqual}
       groupBy={getJoinedCategories}
     />
@@ -246,7 +248,9 @@ export const NodalDiseaseStageAutocomplete = ({
       onChange={(_, value) => field.onChange(value)}
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
-      renderInput={params => <TextField variant="filled" label="Nodal Disease (N) Stage" placeholder="" {...params} />}
+      renderInput={params => (
+        <TextField variant="filled" label="Nodal Disease (N) Stage ⓘ" placeholder="" {...params} />
+      )}
       isOptionEqualToValue={areCodedValueTypesEqual}
       groupBy={getJoinedCategories}
     />
@@ -267,7 +271,7 @@ export const MetastasesStageAutocomplete = ({
       onChange={(_, value) => field.onChange(value)}
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
-      renderInput={params => <TextField variant="filled" label="Metastases (M) Stage" placeholder="" {...params} />}
+      renderInput={params => <TextField variant="filled" label="Metastases (M) Stage ⓘ" placeholder="" {...params} />}
       isOptionEqualToValue={areCodedValueTypesEqual}
       groupBy={getJoinedCategories}
     />

--- a/src/components/SearchForm/FormFields.tsx
+++ b/src/components/SearchForm/FormFields.tsx
@@ -90,7 +90,7 @@ export const AgeTextField = ({
   field,
 }: {
   field: ControllerRenderProps<SearchFormValuesType, 'age'>;
-}): ReactElement => <TextField data-testid="age" fullWidth label="Age ⓘ" type="number" variant="filled" {...field} />;
+}): ReactElement => <TextField data-testid="age" fullWidth label="Age †" type="number" variant="filled" {...field} />;
 
 export const CancerTypeAutocomplete = ({
   field,
@@ -114,7 +114,7 @@ export const CancerTypeAutocomplete = ({
       renderInput={params => (
         <TextField
           variant="filled"
-          label="Cancer Diagnosis ⓘ"
+          label="Cancer Diagnosis †"
           placeholder=""
           required
           error={field.value === null}
@@ -146,7 +146,7 @@ export const CancerSubtypeAutocomplete = ({
       renderInput={params => (
         <TextField
           variant="filled"
-          label="Histology"
+          label="Histology †"
           placeholder=""
           error={!subtypeIsValid()}
           helperText={!subtypeIsValid() ? 'Invalid histology.' : undefined}
@@ -205,7 +205,7 @@ export const DiseaseStatusAutocomplete = ({
       onChange={(_, value) => field.onChange(value)}
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
-      renderInput={params => <TextField variant="filled" label="Disease Status ⓘ" placeholder="" {...params} />}
+      renderInput={params => <TextField variant="filled" label="Disease Status †" placeholder="" {...params} />}
       isOptionEqualToValue={areCodedValueTypesEqual}
     />
   );
@@ -226,7 +226,7 @@ export const PrimaryTumorStageAutocomplete = ({
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
       renderInput={params => (
-        <TextField variant="filled" label="Primary Tumor (T) Stage ⓘ" placeholder="" {...params} />
+        <TextField variant="filled" label="Primary Tumor (T) Stage †" placeholder="" {...params} />
       )}
       isOptionEqualToValue={areCodedValueTypesEqual}
       groupBy={getJoinedCategories}
@@ -249,7 +249,7 @@ export const NodalDiseaseStageAutocomplete = ({
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
       renderInput={params => (
-        <TextField variant="filled" label="Nodal Disease (N) Stage ⓘ" placeholder="" {...params} />
+        <TextField variant="filled" label="Nodal Disease (N) Stage †" placeholder="" {...params} />
       )}
       isOptionEqualToValue={areCodedValueTypesEqual}
       groupBy={getJoinedCategories}
@@ -271,7 +271,7 @@ export const MetastasesStageAutocomplete = ({
       onChange={(_, value) => field.onChange(value)}
       options={options}
       getOptionLabel={(option: CodedValueType) => option.display}
-      renderInput={params => <TextField variant="filled" label="Metastases (M) Stage ⓘ" placeholder="" {...params} />}
+      renderInput={params => <TextField variant="filled" label="Metastases (M) Stage †" placeholder="" {...params} />}
       isOptionEqualToValue={areCodedValueTypesEqual}
       groupBy={getJoinedCategories}
     />
@@ -332,7 +332,7 @@ export const BiomarkersAutocomplete = ({
   return (
     <AutocompleteMulti
       field={field}
-      label="biomarkers"
+      label="biomarkers †"
       options={biomarkers}
       getOptionLabel={(option: Biomarker) => {
         const { display, qualifier } = { ...option };

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -391,6 +391,10 @@ const SearchForm = ({ defaultValues, fullWidth, setUserId, disableLocation }: Se
             />
           </Grid>
 
+          <Grid item xs={8} lg={fullWidth ? 8 : 4} xl={fullWidth ? 8 : 2}>
+            ⓘ Indicates EOM clinical data element
+          </Grid>
+
           <Grid item xs={8}>
             <Button
               sx={{

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -392,7 +392,7 @@ const SearchForm = ({ defaultValues, fullWidth, setUserId, disableLocation }: Se
           </Grid>
 
           <Grid item xs={8} lg={fullWidth ? 8 : 4} xl={fullWidth ? 8 : 2}>
-            ⓘ Indicates EOM clinical data element
+            † Indicates EOM clinical data element
           </Grid>
 
           <Grid item xs={8}>

--- a/src/components/SearchForm/__tests__/SearchForm.test.tsx
+++ b/src/components/SearchForm/__tests__/SearchForm.test.tsx
@@ -63,7 +63,7 @@ describe('<SearchForm />', () => {
     expect(screen.getByTestId('stage')).toBeInTheDocument();
     expect(screen.getByTestId('ecogScore')).toBeInTheDocument();
     expect(screen.getByTestId('karnofskyScore')).toBeInTheDocument();
-    expect(screen.getByTestId('biomarkers')).toBeInTheDocument();
+    expect(screen.getByTestId('biomarkers †')).toBeInTheDocument();
     expect(screen.getByTestId('radiation')).toBeInTheDocument();
     expect(screen.getByTestId('surgery')).toBeInTheDocument();
     expect(screen.getByTestId('medications')).toBeInTheDocument();


### PR DESCRIPTION
This PR changes the "Cancer Subtype" label to "Histology" and the "Cancer Type" label to "Cancer Diagnosis" and adds a "ⓘ" next to any EOM fields with an accompanying note at the bottom saying they are EOM fields. 