### PR TITLE
Rehydrate codes before no-FHIR-server bailout

### DIFF
--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -365,6 +365,13 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const queryClient = new QueryClient();
   const userId = Array.isArray(query['userid']) ? query['userid'].join('') : query['userid'] ?? null;
 
+  // "Rehydrate" codes
+  rehydrateCodes(query, 'metastasis', convertCodesToMetastases);
+  rehydrateCodes(query, 'biomarkers', convertCodesToBiomarkers);
+  rehydrateCodes(query, 'medications', convertCodesToMedications);
+  rehydrateCodes(query, 'radiation', convertCodesToRadiations);
+  rehydrateCodes(query, 'surgery', convertCodesToSurgeries);
+
   if (query['fhirless'] !== undefined) {
     // In this case, the results are "fhirless" and we return a default set of properties
     return {
@@ -393,13 +400,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
   }
 
   const [fhirPatient, fhirUser] = await Promise.all([fhirClient.patient.read(), fhirClient.user.read()]);
-
-  // "Rehydrate" codes
-  rehydrateCodes(query, 'metastasis', convertCodesToMetastases);
-  rehydrateCodes(query, 'biomarkers', convertCodesToBiomarkers);
-  rehydrateCodes(query, 'medications', convertCodesToMedications);
-  rehydrateCodes(query, 'radiation', convertCodesToRadiations);
-  rehydrateCodes(query, 'surgery', convertCodesToSurgeries);
 
   return {
     props: {


### PR DESCRIPTION
This moves the code that "rehydrates" the search codes to before the code that bails out on the rest of the process if there is no FHIR server available to get data from. (This fix should probably also go into the EOM branch.)